### PR TITLE
Waiting for available data on reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ onyx-serial: the simple serial port library by D.
 ## Examples:
 
 ```D
-	import onyx.serial;
+	import onyx.serial.serial_port;
 
 	/* Create ports */
 	auto port1 = OxSerialPort("dev/ttyS1", Speed.B9600, Parity.none, 1000);
@@ -41,7 +41,7 @@ onyx-serial: the simple serial port library by D.
 
 
 ```D
-	string[] s1 = 
+	string[] s1 =
 		["[port]",
 		 "name = /dev/ttyr06",
 		 "speed = 57600",

--- a/dub.sdl
+++ b/dub.sdl
@@ -1,4 +1,4 @@
-name "onyx-serial-dccdn"
+name "onyx-serial"
 description "Serial port interface by D"
 license "MIT"
 copyright "Copyright © 2014-2015"

--- a/dub.sdl
+++ b/dub.sdl
@@ -1,4 +1,4 @@
-name "onyx-serial"
+name "onyx-serial-dccdn"
 description "Serial port interface by D"
 license "MIT"
 copyright "Copyright © 2014-2015"

--- a/source/onyx/serial/read_mode.d
+++ b/source/onyx/serial/read_mode.d
@@ -1,0 +1,9 @@
+module onyx.serial.read_mode;
+
+enum ReadMode
+{
+	no_wait,
+	wait_for_timeout,
+	wait_for_data,
+	wait_for_full_buffer
+}

--- a/source/onyx/serial/read_mode.d
+++ b/source/onyx/serial/read_mode.d
@@ -2,8 +2,8 @@ module onyx.serial.read_mode;
 
 enum ReadMode
 {
-	no_wait,
-	wait_for_timeout,
-	wait_for_data,
-	wait_for_full_buffer
+	noWait,
+	waitForTimeout,
+	waitForData,
+	waitForAllData
 }

--- a/source/onyx/serial/serial_port.d
+++ b/source/onyx/serial/serial_port.d
@@ -251,7 +251,7 @@ struct OxSerialPort
 	 *
 	 * Throws: SerialPortIOException, SerialPortTimeOutException
 	 */
-	ubyte[] read(int byteCount, ReadMode readMode = ReadMode.wait_for_timeout)
+	ubyte[] read(int byteCount, ReadMode readMode = ReadMode.waitForTimeout)
 	{
 		return impl.read(byteCount, readMode);
 	}
@@ -264,7 +264,7 @@ struct OxSerialPort
 	deprecated("Please use read(int, ReadMode) instead")
 	ubyte[] read(int byteCount, bool wait)
 	{
-		return impl.read(byteCount, wait ? ReadMode.wait_for_timeout : ReadMode.no_wait);
+		return impl.read(byteCount, wait ? ReadMode.waitForTimeout : ReadMode.noWait);
 	}
 
 
@@ -666,9 +666,9 @@ private struct PosixImpl
  				break;
  			}
 	 	}
-	 	while(	readMode == ReadMode.wait_for_timeout && (readTimeOut > (Clock.currStdTime() - startTime)/(1000*10)) ||
-	 			readMode == ReadMode.wait_for_full_buffer ||
-	 			readMode == ReadMode.wait_for_data && byteRemains == byteCount);
+	 	while(	readMode == ReadMode.waitForTimeout && (readTimeOut > (Clock.currStdTime() - startTime)/(1000*10)) ||
+	 			readMode == ReadMode.waitForAllData ||
+	 			readMode == ReadMode.waitForData && byteRemains == byteCount);
 	 	
 	 	if (byteRemains == byteCount)
 	 		throw new SerialPortTimeOutException(name, "Port data read timeout. ");


### PR DESCRIPTION
PR born from #4 

Code user can now read without waiting, waiting for timeout, waiting for data available or waiting for enough data to fill the specified buffer size.

I tested it manually since currently we don't have any mock serial port (it seems to work perfectly).

Also, I took the freedom to modify the file hierarchy by creating a serial package and moving serial.d to serial/serial_port.d, since I added a new file.

It's totally up to you to decide the new version number, of course.

In my humble opinion, probably structs and enums from serial_port.d should be split in multiple files for easier maintenance, but that is not urgent.
